### PR TITLE
Feat/개발 4 게시물 목록 조회 api

### DIFF
--- a/src/routers/feeds.router.js
+++ b/src/routers/feeds.router.js
@@ -1,0 +1,76 @@
+import express from 'express';
+import joi from 'joi';
+import { prisma } from '../utils/prisma.util.js';
+
+const feedsRouter = express.Router();
+
+// joi 유효성 검사
+const createdFeedsSchema = joi.object({
+	title: joi.string().required(),
+	content: joi.string().min(150).required(),
+	img_url: joi.string().uri()
+});
+
+// 게시물 작성 API
+feedsRouter.post('/feeds', /*인증*/, async(req, res, next) => {
+	try {
+		const { userId } = req.user;
+		const validation = createdFeedsSchema.validateAsync(req.body);
+		const { title, content, img_url } = validation;
+
+		const nickName = await prisma.users.findFirst({
+			where: { userId },
+			select: {
+				nickName: true
+			}
+		});
+
+		const feed = await prisma.feeds.create({
+			data: {
+				UserId: userId,
+				// FK 외부키로 대문자 U를 하였으나 실제 스키마 적용에따라 수정
+				// 현재 ERD 에는 userId 라고 설정되어 있음
+				nickName,
+				title,
+				content,
+				img_url,
+			},
+			select: {
+				feedId: true,
+				UserId: true,
+				title: true,
+				nickName: true,
+				content: true,
+				img_url: true,
+				createdAt: true,
+				updatedAt: true
+			}
+		});
+		return res.status(201).json({status: 201, message: "게시글 생성에 성공했습니다.", data: feed});
+
+	} catch(error) {
+		next(error);
+	}
+});
+
+// 게시물 목록 조회 API
+
+feedsRouter.get('/feeds', async(req, res, next) => {
+	const orderBy = req.query.sort ? req.query.sort.toLowerCase() : 'desc';
+
+	// 목록 조회 updatedAt 뿐만이 아닌 createdAt 도 필요 대상아닌지 상의
+	const feeds = await prisma.feeds.findMany({
+		select: {
+			feedId: true,
+			title: true,
+			nickName: true,
+			content: true,
+			updatedAt: true
+		},
+		orderBy: { updatedAt: orderBy }
+	});
+
+	return res.status(200).json({status: 200, message: "게시물 목록 조회에 성공하였습니다.", data: feeds});
+})
+
+export default feedsRouter


### PR DESCRIPTION
게시물 목록 조회 API
게시물 목록을 조회합니다.

요청 정보
 Query Parameters(req.query)으로 정렬 조건을 받습니다.
 생성일시 기준 정렬은 과거순(ASC), 최신순(DESC) 으로 전달 받습니다. 값이 없는 경우 최신순(DESC) 정렬을 기본으로 합니다. 대소문자 구분 없이 동작해야 합니다.
예) sort=desc

유효성 검증 및 에러 처리
 일치하는 값이 없는 경우 - 빈 배열([])을 반환합니다. (StatusCode: 200)

비즈니스 로직(데이터 처리)
 전체 게시물 목록을 조회합니다.
 정렬 조건에 따라 다른 결과 값을 조회합니다.

반환 정보
 게시물ID, 제목, 내용, 닉네임, 수정일시를 반환합니다.