### PR TITLE
Feat/개발 4 게시물 삭제 api 

### DIFF
--- a/src/routers/feeds.router.js
+++ b/src/routers/feeds.router.js
@@ -118,14 +118,14 @@ feedsRouter.patch('/feeds/:feedId', requireAccessToken, async(req, res, next) =>
 		if (!title&&!content&&!feed_img_url) {
 			throw new Error('수정할 정보를 입력해주세요.');
 		}
-		const nickName = await prisma.users.findFirst({
+		const nickName = await prisma.users.findFirst({ 
 			where: { userId },
 			celect: {
 				nickName: true
 			}
 		});
 
-		const feed = await prisma.feeds.findFirst({
+		const feed = await prisma.feeds.findFirst({ //unique
 			where: {
 				userId,
 				feedId: +feedId
@@ -162,6 +162,33 @@ feedsRouter.patch('/feeds/:feedId', requireAccessToken, async(req, res, next) =>
 		next(error);
 	}
 
+})
+
+// 게시물 삭제 API
+
+feedsRouter.delete('/feeds/:feedId', requireAccessToken, async(req, res, next) => {
+	try {
+		const userId = req.user;
+		const feedId = req.params;
+		const feed = await prisma.feeds.findUnique({
+			where: {
+				userId,
+				feedId: +feedId
+			}
+		});
+		if (!feed) {
+			throw new Error('게시물이 존재하지 않습니다.')
+		}
+		await prisma.feeds.delete({
+			where: {
+				feedId: +feedId
+			}
+		});
+		return res.status(200).json({status: 200, message: "게시물 삭제에 성공했습니다.", deletedFeedId: +feedId});
+	} catch(error) {
+		next(error);
+	}
+	
 })
 
 


### PR DESCRIPTION
게시물 삭제 API (🔐 AccessToken 인증 필요)
내가 등록 한 게시물을 삭제합니다.

요청 정보
 사용자 정보는 인증 Middleware(req.user)를 통해서 전달 받습니다.
 게시물 ID를 Path Parameters(req.params)로 전달 받습니다.

유효성 검증 및 에러 처리
 게시물 정보가 없는 경우 - “게시물이 존재하지 않습니다.”

비즈니스 로직(데이터 처리)
 현재 로그인 한 사용자가 작성한 게시물만 삭제합니다.
 DB에서 게시물 조회 시 게시물 ID, 작성자 ID가 모두 일치해야 합니다.
 DB에서 게시물 정보를 삭제합니다.

반환 정보
 삭제 된 게시물 ID를 반환합니다.